### PR TITLE
Import nodes and delete keys on node removal

### DIFF
--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package tools


### PR DESCRIPTION
Chef nodes in 12+ created by TF cannot save their own attributes, there is no associated ACL resource even if using the same Chef Server credentials for both the bootstrap generation and the API calls to create nodes. Importing nodes created by bootstrap via cloud-init permits TF-state management of their lifecycle in the Chef Server when the associated TF resource is replaced/removed.

On a related note, the destruction of a node resource leaves the associated key dangling in Chef Server which prevents recreated resources from bootstrapping correctly as they cannot re-register the same name.

Implement importer for Chef node resources and implicit client key cleanup on node destruction.

Key point for TF developers using this: we now have access to the Chef Node attributes collected by Ohai and cookbooks during the pre-import runs as JSON data upon which further iteration/mapping and selection can be performed to pivot logic for lifecycle ops based on those keys and values.